### PR TITLE
Persist the color mode

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -3,7 +3,7 @@ import { ref } from "vue";
 
 import { useColorMode } from "@vueuse/core";
 const mode = useColorMode();
-mode.value = "dark";
+mode.value ||= "dark";
 
 import {
   NavigationMenu,


### PR DESCRIPTION
I believe useColorMode stores/retrieves the value from local storage so only set it to default "dark" if not found